### PR TITLE
Add timezone and return job creation datetime in ISO 8601 format

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -7,6 +7,7 @@ import tornado.template
 import tornado.escape
 import json
 from datetime import datetime
+import pytz
 import bcrypt
 import time
 from dbconnector import DbConnector
@@ -26,6 +27,7 @@ APPCONFIG = {
     # 'auth_token': os.environ['SPT_API_TOKEN'],
     'baseUrl': 'https://mmli.clean.com',
 }
+utc_timezone = pytz.timezone('UTC')
 
 log.info(f"Now starting API server: mysql://{config['db']['user']}:****@{config['db']['host']}:3306/{config['db']['database']}")
 
@@ -644,8 +646,9 @@ class CLEANStatusJobHandler(BaseHandler):
                     responseList = []
                     for job in job_list:
                         job['url'] = APPCONFIG['baseUrl'] + '/jobId/' + job['job_id']
-                        date_time_obj = datetime.datetime.strptime(job['time_created'], '%Y-%m-%d %H:%M:%S')
-                        iso_8601_str = date_time_obj.isoformat()
+                        date_time_obj = datetime.strptime(job['time_created'], '%Y-%m-%d %H:%M:%S')
+                        date_time_obj_utc = utc_timezone.localize(date_time_obj)
+                        iso_8601_str = date_time_obj_utc.isoformat()
                         responseObject = {'jobId':job['job_id'], 'url': job['url'], 'status': job['phase'], 'created_at': iso_8601_str}
                         responseList.append(responseObject)
                     self.send_response(responseList, indent=2)
@@ -744,8 +747,9 @@ class CLEANResultJobHandler(BaseHandler):
             job['url'] = APPCONFIG['baseUrl'] + '/jobId/' + job['job_id']
             output_dir = '/app/results/inputs/'
             fileName = job['job_id'] + '_maxsep.csv'
-            date_time_obj = datetime.datetime.strptime(job['time_created'], '%Y-%m-%d %H:%M:%S')
-            iso_8601_str = date_time_obj.isoformat()
+            date_time_obj = datetime.strptime(job['time_created'], '%Y-%m-%d %H:%M:%S')
+            date_time_obj_utc = utc_timezone.localize(date_time_obj)
+            iso_8601_str = date_time_obj_utc.isoformat()
             responseObject = {'jobId':job['job_id'], 'url': job['url'], 'status': job['phase'], 'created_at': iso_8601_str}
             input_str = ''
             with open(output_dir + fileName, 'r') as f:

--- a/src/main.py
+++ b/src/main.py
@@ -646,9 +646,7 @@ class CLEANStatusJobHandler(BaseHandler):
                     responseList = []
                     for job in job_list:
                         job['url'] = APPCONFIG['baseUrl'] + '/jobId/' + job['job_id']
-                        date_time_obj = datetime.strptime(job['time_created'], '%Y-%m-%d %H:%M:%S')
-                        date_time_obj_utc = utc_timezone.localize(date_time_obj)
-                        iso_8601_str = date_time_obj_utc.isoformat()
+                        iso_8601_str = job['time_created'].replace(tzinfo=utc_timezone).isoformat()
                         responseObject = {'jobId':job['job_id'], 'url': job['url'], 'status': job['phase'], 'created_at': iso_8601_str}
                         responseList.append(responseObject)
                     self.send_response(responseList, indent=2)
@@ -687,7 +685,8 @@ class CLEANStatusJobHandler(BaseHandler):
             if property and property in valid_properties.keys():
                 job = job[valid_properties[property]]
             job['url'] = APPCONFIG['baseUrl'] + '/jobId/' + job['job_id']
-            responseObject = {'jobId':job['job_id'], 'url': job['url'], 'status': job['phase'], 'created_at': job['time_created']}
+            iso_8601_str = job['time_created'].replace(tzinfo=utc_timezone).isoformat()
+            responseObject = {'jobId':job['job_id'], 'url': job['url'], 'status': job['phase'], 'created_at': iso_8601_str}
             self.send_response(responseObject, indent=2)
             self.finish()
             return
@@ -747,9 +746,7 @@ class CLEANResultJobHandler(BaseHandler):
             job['url'] = APPCONFIG['baseUrl'] + '/jobId/' + job['job_id']
             output_dir = '/app/results/inputs/'
             fileName = job['job_id'] + '_maxsep.csv'
-            date_time_obj = datetime.strptime(job['time_created'], '%Y-%m-%d %H:%M:%S')
-            date_time_obj_utc = utc_timezone.localize(date_time_obj)
-            iso_8601_str = date_time_obj_utc.isoformat()
+            iso_8601_str = job['time_created'].replace(tzinfo=utc_timezone).isoformat()
             responseObject = {'jobId':job['job_id'], 'url': job['url'], 'status': job['phase'], 'created_at': iso_8601_str}
             input_str = ''
             with open(output_dir + fileName, 'r') as f:

--- a/src/main.py
+++ b/src/main.py
@@ -595,7 +595,7 @@ class CLEANSubmitJobHandler(BaseHandler):
                     responseBody = {
                         'jobId': job['jobId'],
                         'url' : APPCONFIG['baseUrl'] + '/jobId/' + job['jobId'],
-                        'status' : '1',
+                        'status' : 'executing',
                         'created_at': job['creationTime'] or 0
                     }
                     self.send_response(responseBody, indent=2)
@@ -644,7 +644,9 @@ class CLEANStatusJobHandler(BaseHandler):
                     responseList = []
                     for job in job_list:
                         job['url'] = APPCONFIG['baseUrl'] + '/jobId/' + job['job_id']
-                        responseObject = {'jobId':job['job_id'], 'url': job['url'], 'status': job['phase'], 'created_at': job['time_created']}
+                        date_time_obj = datetime.datetime.strptime(job['time_created'], '%Y-%m-%d %H:%M:%S')
+                        iso_8601_str = date_time_obj.isoformat()
+                        responseObject = {'jobId':job['job_id'], 'url': job['url'], 'status': job['phase'], 'created_at': iso_8601_str}
                         responseList.append(responseObject)
                     self.send_response(responseList, indent=2)
                     self.finish()
@@ -742,7 +744,9 @@ class CLEANResultJobHandler(BaseHandler):
             job['url'] = APPCONFIG['baseUrl'] + '/jobId/' + job['job_id']
             output_dir = '/app/results/inputs/'
             fileName = job['job_id'] + '_maxsep.csv'
-            responseObject = {'jobId':job['job_id'], 'url': job['url'], 'status': job['phase'], 'created_at': job['time_created']}
+            date_time_obj = datetime.datetime.strptime(job['time_created'], '%Y-%m-%d %H:%M:%S')
+            iso_8601_str = date_time_obj.isoformat()
+            responseObject = {'jobId':job['job_id'], 'url': job['url'], 'status': job['phase'], 'created_at': iso_8601_str}
             input_str = ''
             with open(output_dir + fileName, 'r') as f:
                 input_str = f.read().strip()


### PR DESCRIPTION
Change datetime format returned by `/job/status` and `/job/result` api to ISO 8601 format
example: "2023-03-21 22:56:56" -> "2023-03-21T22:56:56+00:00"
