### PR TITLE
Implement authentication via oauth2 proxy

### DIFF
--- a/chart/pvc-explorer.pod.yaml
+++ b/chart/pvc-explorer.pod.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pvc-explorer
+spec:
+  containers:
+    - name: pvc-explorer
+      image: ubuntu:20.04
+      stdin: true 
+      tty: true 
+      workingDir: /app/data/
+      volumeMounts:
+      - mountPath: "/app/data"
+        name: data
+  volumes:
+    - name: data
+      persistentVolumeClaim:
+        # local dev
+        # claimName: job-manager-pvc
+        
+        # prod
+        # claimName: mmli-clean-job-weights
+
+        # staging
+        claimName: mmli-clean-job-weights

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-config
+data:
+  server.override.yaml: |
+    {{ .Values.config | toYaml | nindent 4 }}
+

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -17,16 +17,26 @@ spec:
     spec:
       serviceAccountName: {{ .Release.Name }}-foreman
       volumes:
-        # - name: server-config
-        #   configMap:
-        #     name: {{ .Release.Name }}-config
+        - name: server-config
+          configMap:
+            name: {{ .Release.Name }}-config
         # Volume to host job data
         - name: "job-output"
           persistentVolumeClaim:
-            claimName: "mmli-clean-job-weights" 
+            claimName: {{ .Values.persistence.existingClaim | default "job-manager-pvc" | quote }}
+      initContainers:
+        - name: init-pvc-subpaths    
+          image: busybox
+          command: ['sh', '-c', 'mkdir /app/data/input; mkdir /app/data/output; mkdir /app/data/weights; mkdir /app/data/uws']
+          volumeMounts:
+          - name: "job-output"
+            mountPath: "/app/data/"
       containers:
         - name: jobs-api
           volumeMounts:
+          - name: server-config
+            mountPath: /etc/config/overrides/server.override.yaml
+            subPath: server.override.yaml
           - name: "job-output"
             mountPath: "/app/results/inputs"
             subPath: "output"

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -54,11 +54,13 @@ spec:
           - name: MARIADB_USER
             value: {{ .Values.mariadb.auth.username }}
 
+{{- if .Values.hcaptcha.auth.existingSecret }}
           - name: HCAPTCHA_SECRET
             valueFrom:
               secretKeyRef:
                 name: {{ .Values.hcaptcha.auth.existingSecret }}
                 key: secret
+{{- end }}
 
           ports:
             - containerPort: 8888

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -27,7 +27,7 @@ spec:
       initContainers:
         - name: init-pvc-subpaths    
           image: busybox
-          command: ['sh', '-c', 'mkdir /app/data/input; mkdir /app/data/output; mkdir /app/data/weights; mkdir /app/data/uws']
+          command: ['sh', '-c', 'mkdir -p /app/data/input; mkdir -p /app/data/output; mkdir -p /app/data/weights; mkdir -p /app/data/uws']
           volumeMounts:
           - name: "job-output"
             mountPath: "/app/data/"

--- a/chart/templates/extra-list.yaml
+++ b/chart/templates/extra-list.yaml
@@ -1,0 +1,5 @@
+{{- range .Values.extraDeploy }}
+---
+{{ include "common.tplvalues.render" (dict "value" . "context" $) }}
+{{- end }}
+

--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -5,7 +5,7 @@ metadata:
   name: jobs-api
 {{- with .Values.ingress.annotations }}
   annotations:
-  {{ toYaml . | nindent 4 }}
+  {{- toYaml . | nindent 4 }}
 {{- end }}
 spec:
 {{- if .Values.ingress.tls }}

--- a/chart/templates/persistence.yaml
+++ b/chart/templates/persistence.yaml
@@ -1,30 +1,37 @@
-#apiVersion: v1
-#kind: PersistentVolume
-#metadata:
-#  name: job-manager-pv
-#spec:
-#  {{- if .Values.persistence.storageClassName }}
-#  storageClassName: {{ .Values.persistence.storageClassName }}
-#  {{- end }}
-#  capacity:
-#    storage: {{ .Values.persistence.storageSize }}
-#  accessModes:
-#    - ReadWriteMany
-#  hostPath:
-#    path: /Users/yashdeepthorat/NCSA/mmli-job-manager/data
-#  persistentVolumeReclaimPolicy: Recycle
-#---
-#kind: PersistentVolumeClaim
-#apiVersion: v1
-#metadata:
-#  name: job-manager-pvc
-#spec:
-#  accessModes:
-#    - ReadWriteMany
-#  resources:
-#    requests:
-#      storage: {{ .Values.persistence.storageSize }}
-#{{- if .Values.persistence.storageClassName }}
-#  storageClassName: {{ .Values.persistence.storageClassName }}
-#{{- end }}
-#  volumeName: job-manager-pv
+{{- if not .Values.persistence.existingClaim }}
+{{- if .Values.persistence.hostpath }}
+# Manually link PV for hostpath volume
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: job-manager-pv
+spec:
+  {{- if .Values.persistence.storageClassName }}
+  storageClassName: {{ .Values.persistence.storageClassName }}
+  {{- end }}
+  capacity:
+    storage: {{ .Values.persistence.storageSize }}
+  accessModes:
+    - ReadWriteMany
+  hostPath:
+    path: {{ .Values.persistence.hostpath }}
+  persistentVolumeReclaimPolicy: Recycle
+---
+{{- end }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: job-manager-pvc
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: {{ .Values.persistence.storageSize }}
+{{- if .Values.persistence.storageClassName }}
+  storageClassName: {{ .Values.persistence.storageClassName }}
+{{- end }}
+{{- if .Values.persistence.hostpath }}
+  volumeName: job-manager-pv
+{{- end }}
+{{- end }}

--- a/chart/values.local.yaml
+++ b/chart/values.local.yaml
@@ -4,11 +4,15 @@ ingress:
 #persistence:
 #  storageClassName: hostpath
 
+controller:
+  image: moleculemaker/mmli-job-manager:dev
+
 mariadb:
   enabled: true
 #  global:
 #    storageClass: hostpath
   auth:
+    existingSecret: ""
     rootPassword: "mmli"
     password: "mmli"
     username: "mmli"

--- a/chart/values.local.yaml
+++ b/chart/values.local.yaml
@@ -1,8 +1,22 @@
 ingress:
   ingressClassName: nginx
+  hostname: jobmgr.proxy.localhost
+  tls: true
+  annotations:
+    nginx.ingress.kubernetes.io/enable-cors: "true"
+    nginx.ingress.kubernetes.io/cors-allow-origin: "https://clean.proxy.localhost"
+    nginx.ingress.kubernetes.io/cors-allow-credentials: "true"
 
-#persistence:
-#  storageClassName: hostpath
+
+persistence:
+  existingClaim: ""  # use locally mounted data instead
+
+  # Override the default StorageClass
+  storageClassName: hostpath
+
+  # EXPERIMENTAL: Set this to enable mounting a directory into this volume from host
+  # hostpath: /Users/lambert8/workspace/mmli/mmli-job-manager/data
+
 
 controller:
   image: moleculemaker/mmli-job-manager:dev
@@ -17,3 +31,39 @@ mariadb:
     password: "mmli"
     username: "mmli"
     database: "mmli"
+
+config:
+  server:
+    protocol: "https"
+    ## API hostname. Must match the ingress.hostname value.
+    hostName: "jobmgr.proxy.localhost"
+    namespace: "mmli"
+  hcaptcha:
+    secret: "ChangeThisInProduction"
+  oauth:
+    userInfoUrl: "http://oauth2-proxy.mmli.svc.cluster.local/oauth2/userinfo"
+  uws:
+    ## Server working directory to store generated job data
+    workingVolume:
+      claimName: "job-manager-pvc"
+      mountPath: "/uws"
+      subPath: "uws"
+    ## Central data volumes to be mounted in job containers
+    volumes:
+      - name: 'job-output'
+        mountPath: '/app/data/inputs'
+        subPath: 'input'
+        claimName: 'job-manager-pvc'
+      - name: 'job-output'
+        mountPath: '/app/results/inputs'
+        subPath: 'output'
+        claimName: 'job-manager-pvc'
+      - name: 'job-output'
+        mountPath: '/root/.cache/torch/hub/checkpoints'
+        subPath: 'weights'
+        claimName: 'job-manager-pvc'
+    # - name: data
+    #   claimName: mmli-data-pvc
+    #   mountPath: "/data/mmli"
+    #   subPath: ""
+    #   readOnly: true

--- a/chart/values.prod.yaml
+++ b/chart/values.prod.yaml
@@ -5,6 +5,7 @@ ingress:
     cert-manager.io/cluster-issuer: letsencrypt-production
     kubernetes.io/tls-acme: "true"
     traefik.ingress.kubernetes.io/router.tls: "true"
+    traefik.ingress.kubernetes.io/router.middlewares: oauth2-proxy-cors-header@kubernetescrd
 
 persistence:
   existingClaim: "mmli-clean-job-weights"

--- a/chart/values.prod.yaml
+++ b/chart/values.prod.yaml
@@ -5,8 +5,12 @@ ingress:
     cert-manager.io/cluster-issuer: letsencrypt-production
     kubernetes.io/tls-acme: "true"
     traefik.ingress.kubernetes.io/router.tls: "true"
+    nginx.ingress.kubernetes.io/enable-cors: "true"
+    nginx.ingress.kubernetes.io/cors-allow-origin: "https://clean.frontend.mmli1.ncsa.illinois.edu"
+    nginx.ingress.kubernetes.io/cors-allow-credentials: "true"
 
 persistence:
+  existingClaim: "mmli-clean-job-weights"
   storageClassName: csi-cinder-sc-retain
   storageSize: "100Gi"
 
@@ -22,3 +26,36 @@ hcaptcha:
   auth:
     existingSecret: "hcaptcha"
 
+config:
+  server:
+    protocol: "https"
+    ## API hostname. Must match the ingress.hostname value.
+    hostName: "jobmgr.mmli1.ncsa.illinois.edu"
+    namespace: "job-manager"
+  oauth:
+    userInfoUrl: "http://oauth2-proxy.oauth2-proxy.svc.cluster.local/oauth2/userinfo"
+  uws:
+    ## Server working directory to store generated job data
+    workingVolume:
+      claimName: "mmli-clean-job-weights"
+      mountPath: "/uws"
+      subPath: "uws"
+    ## Central data volumes to be mounted in job containers
+    volumes:
+      - name: 'job-output'
+        mountPath: '/app/data/inputs'
+        subPath: 'input'
+        claimName: 'mmli-clean-job-weights'
+      - name: 'job-output'
+        mountPath: '/app/results/inputs'
+        subPath: 'output'
+        claimName: 'mmli-clean-job-weights'
+      - name: 'job-output'
+        mountPath: '/root/.cache/torch/hub/checkpoints'
+        subPath: 'weights'
+        claimName: 'mmli-clean-job-weights'
+    # - name: data
+    #   claimName: mmli-data-pvc
+    #   mountPath: "/data/mmli"
+    #   subPath: ""
+    #   readOnly: true

--- a/chart/values.prod.yaml
+++ b/chart/values.prod.yaml
@@ -5,9 +5,6 @@ ingress:
     cert-manager.io/cluster-issuer: letsencrypt-production
     kubernetes.io/tls-acme: "true"
     traefik.ingress.kubernetes.io/router.tls: "true"
-    nginx.ingress.kubernetes.io/enable-cors: "true"
-    nginx.ingress.kubernetes.io/cors-allow-origin: "https://clean.frontend.mmli1.ncsa.illinois.edu"
-    nginx.ingress.kubernetes.io/cors-allow-credentials: "true"
 
 persistence:
   existingClaim: "mmli-clean-job-weights"

--- a/chart/values.staging.yaml
+++ b/chart/values.staging.yaml
@@ -32,7 +32,7 @@ extraDeploy:
   kind: Middleware
   metadata:
     name: cors-header
-    namespace: job-manager
+    namespace: staging
   spec:
     headers:
       accessControlAllowCredentials: true

--- a/chart/values.staging.yaml
+++ b/chart/values.staging.yaml
@@ -5,6 +5,7 @@ ingress:
     cert-manager.io/cluster-issuer: letsencrypt-production
     kubernetes.io/tls-acme: "true"
     traefik.ingress.kubernetes.io/router.tls: "true"
+    traefik.ingress.kubernetes.io/router.middlewares: staging-cors-header@kubernetescrd
 
 controller:
   image: moleculemaker/mmli-job-manager:staging
@@ -25,6 +26,35 @@ mariadb:
 hcaptcha:
   auth:
     existingSecret: "hcaptcha"
+
+extraDeploy:
+- apiVersion: traefik.containo.us/v1alpha1
+  kind: Middleware
+  metadata:
+    name: cors-header
+    namespace: job-manager
+  spec:
+    headers:
+      accessControlAllowCredentials: true
+      accessControlAllowHeaders:
+      - Origin
+      - X-Requested-With
+      - Content-Type
+      - content-type
+      - Accept
+      - Authorization
+      accessControlAllowMethods:
+      - GET
+      - OPTIONS
+      - PUT
+      - DELETE
+      - POST
+      accessControlAllowOriginList:
+      - https://clean.frontend.mmli1.ncsa.illinois.edu
+      - https://clean.frontend.staging.mmli1.ncsa.illinois.edu
+      - https://jobmgr.mmli1.ncsa.illinois.edu
+      - https://jobmgr.staging.mmli1.ncsa.illinois.edu
+
 
 config:
   server:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -12,6 +12,10 @@ persistence:
   storageClassName: "job-manager-storage-class"
   storageSize: "10Gi"
 
+hcaptcha:
+  auth:
+    existingSecret: ""
+
 # https://artifacthub.io/packages/helm/bitnami/mariadb?modal=values
 mariadb:
   enabled: true

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,5 +1,5 @@
 ingress:
-  hostname: jobmgr.localhost
+  hostname: jobmgr.proxy.localhost
   tls: false
   annotations: {}
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -6,11 +6,16 @@ ingress:
 controller:
   image: moleculemaker/mmli-job-manager:main
 
+
 persistence:
   # Set this to use a particular StorageClass
-  # Unset this to use a clsuter default StorageClass
-  storageClassName: "job-manager-storage-class"
+  # Unset this to use a cluster default StorageClass
+  storageClassName: ""
+  existingClaim: ""
   storageSize: "10Gi"
+
+  # EXPERIMENTAL: Set this to enable mounting a directory into this volume from host
+  hostpath: ""
 
 hcaptcha:
   auth:
@@ -32,3 +37,6 @@ mariadb:
 
     # Set the name of your mariadb database
     database: "mmli"
+
+# Override server.yaml at runtime
+config: {}

--- a/config/server.yaml
+++ b/config/server.yaml
@@ -18,6 +18,7 @@ db:
 hcaptcha:
   secret: "ChangeThisInProduction"
 oauth:
+  # FIXME: may need to support hostAlias to .localhost here
   #userInfoUrl: "http://oauth.proxy.localhost"
   userInfoUrl: "https://mmli1.ncsa.illinois.edu/oauth2/userinfo"
   cookieName: "_oauth2_proxy"

--- a/config/server.yaml
+++ b/config/server.yaml
@@ -16,7 +16,11 @@ db:
   pass: ""
   database: ""
 hcaptcha:
-  secret: ""
+  secret: "ChangeThisInProduction"
+oauth:
+  #userInfoUrl: "http://oauth.proxy.localhost"
+  userInfoUrl: "https://mmli1.ncsa.illinois.edu/oauth2/userinfo"
+  cookieName: "_oauth2_proxy"
 email:
   server: "smtp.ncsa.uiuc.edu"
   fromEmail: "devnull+clean@ncsa.illinois.edu"
@@ -38,6 +42,8 @@ uws:
       pullSecrets: []
     ## Abort jobs after 3 days regardless of their behavior
     activeDeadlineSeconds: 259200
+    ## Cleanup completed/failed jobs after 12 hours
+    ttlSecondsAfterFinished: 43200
     ## Poll the log file for changes every `logFilePollingPeriod` seconds
     logFilePollingPeriod: 300
     ## CAUTION: Discrepancy between the UID of the image user and the mmli API server UID

--- a/config/server.yaml
+++ b/config/server.yaml
@@ -18,9 +18,7 @@ db:
 hcaptcha:
   secret: "ChangeThisInProduction"
 oauth:
-  # FIXME: may need to support hostAlias to .localhost here
-  #userInfoUrl: "http://oauth.proxy.localhost"
-  userInfoUrl: "https://mmli1.ncsa.illinois.edu/oauth2/userinfo"
+  userInfoUrl: "http://oauth2-proxy.oauth2-proxy.svc.cluster.local/oauth2/userinfo"
   cookieName: "_oauth2_proxy"
 email:
   server: "smtp.ncsa.uiuc.edu"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,7 +18,7 @@ services:
     volumes:
       - db:/var/lib/mysql
   app:
-    image: moleculemaker/mmli-job-manager:dev
+    image: moleculemaker/mmli-job-manager:staging
     container_name: mmli-jobs-api-server
     build:
       context: .

--- a/src/global_vars.py
+++ b/src/global_vars.py
@@ -35,6 +35,8 @@ config['db']['user'] = os.environ.get('MARIADB_USER', config['db']['user'])
 config['db']['pass'] = os.environ.get('MARIADB_PASSWORD', config['db']['pass'])
 config['db']['database'] = os.environ.get('MARIADB_DATABASE', config['db']['database'])
 config['hcaptcha']['secret'] = os.environ.get('HCAPTCHA_SECRET', config['hcaptcha']['secret'])
+config['oauth']['userInfoUrl'] = os.environ.get('OAUTH_USERINFO_URL', config['oauth']['userInfoUrl'])
+config['oauth']['cookieName'] = os.environ.get('OAUTH_COOKIE_NAME', config['oauth']['cookieName'])
 
 # Configure logging
 logging.basicConfig(

--- a/src/kubejob.py
+++ b/src/kubejob.py
@@ -163,7 +163,7 @@ def delete_job(job_id: str) -> None:
     #     raise
 
 
-def create_job(command, run_id=None, owner_id=None, replicas=1, environment=None, job_config=None):
+def create_job(command, job_id=None, run_id=None, owner_id=None, replicas=1, environment=None):
     response = {
         'job_id': None,
         'message': None,
@@ -171,7 +171,8 @@ def create_job(command, run_id=None, owner_id=None, replicas=1, environment=None
     }
     try:
         namespace = get_namespace()
-        job_id = generate_uuid()
+        if not job_id:
+            job_id = generate_uuid()
         if not run_id:
             run_id = job_id
         job_name = get_job_name_from_id(job_id)

--- a/src/kubejob.py
+++ b/src/kubejob.py
@@ -163,7 +163,7 @@ def delete_job(job_id: str) -> None:
     #     raise
 
 
-def create_job(command, run_id=None, owner_id=None, replicas=1, environment=None, job_config=""):
+def create_job(command, run_id=None, owner_id=None, replicas=1, environment=None, job_config=None):
     response = {
         'job_id': None,
         'message': None,
@@ -215,9 +215,6 @@ def create_job(command, run_id=None, owner_id=None, replicas=1, environment=None
             templateText = f.read()
         template = Template(templateText)
 
-        encoded_data = base64.b64encode(job_config.encode('utf-8')).decode('utf-8')
-        mount_path = '/app/data/inputs'
-
         job_body = yaml.safe_load(template.render(
             name=job_name,
             runId=run_id,
@@ -247,7 +244,7 @@ def create_job(command, run_id=None, owner_id=None, replicas=1, environment=None
                 # Runs the CLEAN command on the input file and stores the output to log file at /uws/jobs/<jobId>/out/log
                 # In case the CLEAN command has an exception, an error file is created at  /uws/jobs/<jobId>/out/error for which the monitor looks for
                 # In an error condition, we still want the entire command to be False so that the "finished" file is not created (it is created as {command} && touch finished), therefore, error condition is ANDed with False
-            command=f'''echo {encoded_data} | base64 -d > {mount_path}/{job_id}.fasta && ((python CLEAN_infer_fasta.py --fasta_data {job_id} >> {job_output_dir}/log) || (touch {job_output_dir}/error && false))''',
+            command=command,
 
             environment=environment,
             uws_root_dir=config['uws']['workingVolume']['mountPath'],
@@ -261,6 +258,7 @@ def create_job(command, run_id=None, owner_id=None, replicas=1, environment=None
             apiToken='dummy',
             jobCompleteApiUrl=jobCompleteApiUrl,
             # releaseName=os.environ.get('RELEASE_NAME', 'dummy'),
+            ttlSecondsAfterFinished=config['uws']['job']['ttlSecondsAfterFinished'],
             activeDeadlineSeconds=config['uws']['job']['activeDeadlineSeconds'],
             monitorEnabled=config['uws']['job']['monitorEnabled'],
         ))

--- a/src/main.py
+++ b/src/main.py
@@ -1,3 +1,5 @@
+import base64
+import logging
 import os
 import global_vars
 from global_vars import STATUS_OK, config, log
@@ -17,6 +19,8 @@ from jobutils import valid_job_id, construct_job_object
 import email_utils
 import requests
 from requests.exceptions import Timeout
+
+import userinfo
 
 # Get global instance of the job handler database interface
 db = DbConnector(
@@ -215,19 +219,24 @@ class JobReportCompleteHandler(BaseHandler):
 
 class JobHandler(BaseHandler):
     def put(self):
+        user = None
+        if 'oauth' in config and 'cookieName' in config['oauth'] and config['oauth']['cookieName'] in self.request.cookies:
+            cookie_name = config['oauth']['cookieName']
+            user = userinfo.validate_auth_cookie(self.request)
+            log.debug('User: ' + str(user))
+
+        if user is None:
+            log.error('401 Unauthorized')
+            self.send_response('401: Unauthorized', http_status_code=401, return_json=False)
+            self.finish()
+            return
+
         try:
             echo = self.getarg('echo') # required
 
             job_config = {
                 'echo': echo,
             }
-
-            ## Command that the job container will execute. The `$JOB_OUTPUT_DIR` environment variable is
-            ## populated at run time after a job ID and output directory have been provisioned.
-            command = f'''echo {echo} | tee $JOB_OUTPUT_DIR/job.log'''
-            log.debug(f"Job command: {command}")
-
-            ## Options:
 
             ## environment is a list of environment variable names and values like [{'name': 'env1', 'value': 'val1'}]
             environment = self.getarg('environment', default=[]) # optional
@@ -257,6 +266,15 @@ class JobHandler(BaseHandler):
                 str(e), http_status_code=global_vars.HTTP_SERVER_ERROR, return_json=False)
             self.finish()
             return
+
+        ## Command that the job container will execute. The `$JOB_OUTPUT_DIR` environment variable is
+        ## populated at run time after a job ID and output directory have been provisioned.
+        encoded_data = base64.b64encode(job_config.encode('utf-8')).decode('utf-8')
+        mount_path = '/app/data/inputs'
+        command = f'''echo {encoded_data} | base64 -d > {mount_path}/{run_id}.fasta && ((python CLEAN_infer_fasta.py --fasta_data {run_id} >> {job_output_dir}/log) || (touch {job_output_dir}/error && false))'''
+        log.debug(f"Job command: {command}")
+
+        ## Options:
 
         response = kubejob.create_job(
             command=command,
@@ -346,6 +364,18 @@ class JobHandler(BaseHandler):
             return
 
     def get(self, job_id=None, property=None):
+        user = None
+        if 'oauth' in config and 'cookieName' in config['oauth'] and config['oauth']['cookieName'] in self.request.cookies:
+            cookie_name = config['oauth']['cookieName']
+            user = userinfo.validate_auth_cookie(self.request)
+            log.debug('User: ' + str(user))
+
+        if user is None:
+            log.error('401 Unauthorized')
+            self.send_response('401: Unauthorized', http_status_code=401, return_json=False)
+            self.finish()
+            return
+
         # See https://www.ivoa.net/documents/UWS/20161024/REC-UWS-1.1-20161024.html#resourceuri
         ## The valid properties are the keys of the returned job data structure
         valid_properties = {
@@ -413,6 +443,18 @@ class JobHandler(BaseHandler):
             return
 
     def delete(self, job_id=None):
+        user = None
+        if 'oauth' in config and 'cookieName' in config['oauth'] and config['oauth']['cookieName'] in self.request.cookies:
+            cookie_name = config['oauth']['cookieName']
+            user = userinfo.validate_auth_cookie(self.request)
+            log.debug('User: ' + str(user))
+
+        if user is None:
+            log.error('401 Unauthorized')
+            self.send_response('401: Unauthorized', http_status_code=401, return_json=False)
+            self.finish()
+            return
+
         try:
             assert valid_job_id(job_id)
         except Exception as e:
@@ -493,7 +535,7 @@ class CLEANSubmitJobHandler(BaseHandler):
             'message': message
         }
         return responseBody
-    
+
     def verify_captcha(self, captcha_token):
         hcaptcha_secret = config['hcaptcha']['secret']
         try:
@@ -519,57 +561,67 @@ class CLEANSubmitJobHandler(BaseHandler):
             return False
         
     def post(self):
-        try:
-            data = json.loads(self.request.body)
-            user_email = 'dummy@example.com'
-            job_config = ""
-            
-            if len(data) == 0:
-                raise Exception('JSON body is empty.')
-            if 'user_email' in data:
-                user_email = data['user_email']
-            if 'captcha_token' in data:
-                if not self.verify_captcha(data['captcha_token']):
-                    raise Exception('Captcha is invalid.')
-            else:
-                raise Exception('Captcha is missing.')
-            
-            # Convert JSON to FASTA format
-            for record in data['input_fasta']:
-                # Check for valid amino acid characters
-                if not re.match('^[ACDEFGHIKLMNPQRSTVWY]+$', record["sequence"]):
-                    raise Exception('Invalid FASTA Protein Sequence')
-                job_config += ">{}\n{}\n".format(record["header"], record["sequence"])
+        user = None
+        if 'oauth' in config and 'cookieName' in config['oauth'] and config['oauth']['cookieName'] in self.request.cookies:
+            cookie_name = config['oauth']['cookieName']
+            user = userinfo.validate_auth_cookie(self.request)
+            log.debug('User: ' + str(user))
 
-
-            ## Command that the job container will execute. The `$JOB_OUTPUT_DIR` environment variable is
-            ## populated at run time after a job ID and output directory have been provisioned.
-            command = f'''cat /tmp/input.fasta'''
-
-            ## environment is a list of environment variable names and values like [{'name': 'env1', 'value': 'val1'}]
-            environment = self.getarg('environment', default=[]) # optional
-
-            ## Number of parallel job containers to run. The containers will execute identical code. Coordination is the
-            ## responsibility of the job owner.
-            ## replicas = self.getarg('replicas', default=1) # optional
-            replicas = 1
-
-            ## Valid run_id value follows the Kubernetes label value constraints:
-            ##   - must be 63 characters or less (cannot be empty),
-            ##   - must begin and end with an alphanumeric character ([a-z0-9A-Z]),
-            ##   - could contain dashes (-), underscores (_), dots (.), and alphanumerics between.
-            ## See also:
-            ##   - https://www.ivoa.net/documents/UWS/20161024/REC-UWS-1.1-20161024.html#runId
-            ##   - https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
-            run_id = self.getarg('run_id', default='') # optional
-            if run_id and (not isinstance(run_id, str) or run_id != re.sub(r'[^-._a-zA-Z0-9]', "", run_id) or not re.match(r'[a-zA-Z0-9]', run_id)):
-                raise Exception('Invalid run_id. Must be 63 characters or less and begin with alphanumeric character and contain only dashes (-), underscores (_), dots (.), and alphanumerics between.')
-            user_id = 'DummyID'
-        except Exception as e:
-            self.send_response(
-                self.failed_job_response(str(e.args[0])), http_status_code=global_vars.HTTP_BAD_REQUEST, return_json=False)
+        if user is None:
+            log.error('401 Unauthorized')
+            self.send_response('401: Unauthorized', http_status_code=401, return_json=False)
             self.finish()
             return
+
+
+        # if 'captcha_token' in data:
+        #     # Fallback attempt to hcaptcha without _oauth2_proxy cookie
+        #     if self.verify_captcha(data['captcha_token']):
+        #         pass
+        #     else:
+        #         raise Exception('Captcha is invalid.')
+        # else:
+        #     raise Exception('No authentication included. Please include either captcha_token or _oauth2_proxy cookie with requests')
+
+
+        user_email = user['email']
+        job_config = ""
+        data = json.loads(self.request.body)
+
+        if len(data) == 0:
+            raise Exception('JSON body is empty.')
+
+        # Convert JSON to FASTA format
+        for record in data['input_fasta']:
+            # Check for valid amino acid characters
+            if not re.match('^[ACDEFGHIKLMNPQRSTVWY]+$', record["sequence"]):
+                raise Exception('Invalid FASTA Protein Sequence')
+            job_config += ">{}\n{}\n".format(record["header"], record["sequence"])
+
+
+        ## Command that the job container will execute. The `$JOB_OUTPUT_DIR` environment variable is
+        ## populated at run time after a job ID and output directory have been provisioned.
+        command = f'''cat /tmp/input.fasta'''
+
+        ## environment is a list of environment variable names and values like [{'name': 'env1', 'value': 'val1'}]
+        environment = self.getarg('environment', default=[]) # optional
+
+        ## Number of parallel job containers to run. The containers will execute identical code. Coordination is the
+        ## responsibility of the job owner.
+        ## replicas = self.getarg('replicas', default=1) # optional
+        replicas = 1
+
+        ## Valid run_id value follows the Kubernetes label value constraints:
+        ##   - must be 63 characters or less (cannot be empty),
+        ##   - must begin and end with an alphanumeric character ([a-z0-9A-Z]),
+        ##   - could contain dashes (-), underscores (_), dots (.), and alphanumerics between.
+        ## See also:
+        ##   - https://www.ivoa.net/documents/UWS/20161024/REC-UWS-1.1-20161024.html#runId
+        ##   - https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
+        run_id = self.getarg('run_id', default='') # optional
+        if run_id and (not isinstance(run_id, str) or run_id != re.sub(r'[^-._a-zA-Z0-9]', "", run_id) or not re.match(r'[a-zA-Z0-9]', run_id)):
+            raise Exception('Invalid run_id. Must be 63 characters or less and begin with alphanumeric character and contain only dashes (-), underscores (_), dots (.), and alphanumerics between.')
+        user_id = 'DummyID'
 
         response = kubejob.create_job(
             command=command,
@@ -584,89 +636,96 @@ class CLEANSubmitJobHandler(BaseHandler):
             self.send_response(response['message'], http_status_code=global_vars.HTTP_SERVER_ERROR, return_json=False)
             self.finish()
             return
-        try:
-            timeout = 30
-            while timeout > 0:
-                results = kubejob.list_jobs(
-                    job_id=response['job_id'],
-                )
-                if results['jobs']:
-                    job = construct_job_object(results['jobs'][0])
-                    try:
-                        user_agent = self.request.headers["User-Agent"]
-                    except:
-                        user_agent = ''
-                    queue_position = 0
-                    try:
-                        ## TODO: Replace with specialized query that uses the SQL count() command
-                        job_list = []
-                        for phase in ['pending', 'queued', 'executing']:
-                            job_list.extend(db.select_job_records(phase=phase, fields=['id']))
-                        log.debug(job_list)
-                        queue_position = len(job_list)
-                    except Exception as e:
-                        log.error(f'''Error querying job queue position: {e}''')
-                    try:
-                        command = job['parameters']['command']
-                        if isinstance(command, list):
-                            command = ' '.join(command)
-                        ## TODO: Replace the JSON dump of the full job info with proper table records.
-                        job_info = {
-                            'job_id': job['jobId'],
-                            'run_id': job['runId'],
-                            'user_id': job['ownerId'],
-                            'command': command,
-                            'type': 'cutout',
-                            'phase': job['phase'],
-                            'time_created': job['creationTime'] or 0,
-                            'time_start': job['startTime'] or 0,
-                            'time_end': job['endTime'] or 0,
-                            'user_agent': user_agent,
-                            'email': user_email,
-                            'job_info': json.dumps(job, default = self.json_converter),
-                            'queue_position': queue_position,
-                            }
-                        db.insert_job_record(job_info)
-                        ##
-                        ## TODO: This is a hack for testing locally, because the monitor sidecar container
-                        ##       would be calling back to the API server with a job start and end report.
-                        ##
-                        if not config['uws']['job']['monitorEnabled']:
-                            log.debug(f'''Updating started job "{job_info['job_id']}"...''')
-                            db.update_job(
-                                job_id=job_info['job_id'],
-                                phase='executing',
-                                start_time=datetime.utcnow(),
-                            )
-                    except Exception as e:
-                        err_msg = f'''Error recording job in database: {e}'''
-                        log.error(err_msg)
-                        self.send_response(err_msg, http_status_code=global_vars.HTTP_SERVER_ERROR, return_json=False)
-                        self.finish()
-                        return
-                    responseBody = {
-                        'jobId': job['jobId'],
-                        'url' : APPCONFIG['baseUrl'] + '/jobId/' + job['jobId'],
-                        'status' : 'executing',
-                        'created_at': job['creationTime'] or 0
-                    }
-                    self.send_response(responseBody, indent=2)
+        timeout = 30
+        while timeout > 0:
+            results = kubejob.list_jobs(
+                job_id=response['job_id'],
+            )
+            if results['jobs']:
+                job = construct_job_object(results['jobs'][0])
+                try:
+                    user_agent = self.request.headers["User-Agent"]
+                except:
+                    user_agent = ''
+                queue_position = 0
+                try:
+                    ## TODO: Replace with specialized query that uses the SQL count() command
+                    job_list = []
+                    for phase in ['pending', 'queued', 'executing']:
+                        job_list.extend(db.select_job_records(phase=phase, fields=['id']))
+                    log.debug(job_list)
+                    queue_position = len(job_list)
+                except Exception as e:
+                    log.error(f'''Error querying job queue position: {e}''')
+                try:
+                    command = job['parameters']['command']
+                    if isinstance(command, list):
+                        command = ' '.join(command)
+                    ## TODO: Replace the JSON dump of the full job info with proper table records.
+                    job_info = {
+                        'job_id': job['jobId'],
+                        'run_id': job['runId'],
+                        'user_id': job['ownerId'],
+                        'command': command,
+                        'type': 'cutout',
+                        'phase': job['phase'],
+                        'time_created': job['creationTime'] or 0,
+                        'time_start': job['startTime'] or 0,
+                        'time_end': job['endTime'] or 0,
+                        'user_agent': user_agent,
+                        'email': user_email,
+                        'job_info': json.dumps(job, default = self.json_converter),
+                        'queue_position': queue_position,
+                        }
+                    db.insert_job_record(job_info)
+                    ##
+                    ## TODO: This is a hack for testing locally, because the monitor sidecar container
+                    ##       would be calling back to the API server with a job start and end report.
+                    ##
+                    if not config['uws']['job']['monitorEnabled']:
+                        log.debug(f'''Updating started job "{job_info['job_id']}"...''')
+                        db.update_job(
+                            job_id=job_info['job_id'],
+                            phase='executing',
+                            start_time=datetime.utcnow(),
+                        )
+                except Exception as e:
+                    err_msg = f'''Error recording job in database: {e}'''
+                    log.error(err_msg)
+                    self.send_response(err_msg, http_status_code=global_vars.HTTP_SERVER_ERROR, return_json=False)
                     self.finish()
                     return
-                else:
-                    timeout -= 1
-                    time.sleep(0.300)
-            self.send_response("Job creation timed out.", http_status_code=global_vars.HTTP_SERVER_ERROR, return_json=False)
-            self.finish()
-            return
-        except Exception as e:
-            self.send_response(str(e), http_status_code=global_vars.HTTP_SERVER_ERROR, return_json=False)
-            self.finish()
-            return
+                responseBody = {
+                    'jobId': job['jobId'],
+                    'url' : APPCONFIG['baseUrl'] + '/jobId/' + job['jobId'],
+                    'status' : 'executing',
+                    'created_at': job['creationTime'] or 0
+                }
+                self.send_response(responseBody, indent=2)
+                self.finish()
+                return
+            else:
+                timeout -= 1
+                time.sleep(0.300)
+        self.send_response("Job creation timed out.", http_status_code=global_vars.HTTP_SERVER_ERROR, return_json=False)
+        self.finish()
+        return
         
 
 class CLEANStatusJobHandler(BaseHandler):
     def post(self):
+        user = None
+        if 'oauth' in config and 'cookieName' in config['oauth'] and config['oauth']['cookieName'] in self.request.cookies:
+            cookie_name = config['oauth']['cookieName']
+            user = userinfo.validate_auth_cookie(self.request)
+            log.debug('User: ' + str(user))
+
+        if user is None:
+            log.error('401 Unauthorized')
+            self.send_response('401: Unauthorized', http_status_code=401, return_json=False)
+            self.finish()
+            return
+
         job_id = self.getarg('jobId', default='')
 
         # See https://www.ivoa.net/documents/UWS/20161024/REC-UWS-1.1-20161024.html#resourceuri
@@ -748,7 +807,20 @@ class CLEANStatusJobHandler(BaseHandler):
 
 
 class CLEANResultJobHandler(BaseHandler):
+
      def post(self):
+        user = None
+        if 'oauth' in config and 'cookieName' in config['oauth'] and config['oauth']['cookieName'] in self.request.cookies:
+            cookie_name = config['oauth']['cookieName']
+            user = userinfo.validate_auth_cookie(self.request)
+            log.debug('User: ' + str(user))
+
+        if user is None:
+            log.error('401 Unauthorized')
+            self.send_response('401: Unauthorized', http_status_code=401, return_json=False)
+            self.finish()
+            return
+
         job_id = self.getarg('jobId', default='')
 
         # See https://www.ivoa.net/documents/UWS/20161024/REC-UWS-1.1-20161024.html#resourceuri

--- a/src/main.py
+++ b/src/main.py
@@ -623,6 +623,8 @@ class CLEANSubmitJobHandler(BaseHandler):
         # Build up path to output dir
         # FIXME: feature envy?
         job_id = kubejob.generate_uuid()
+        if not run_id:
+            run_id = job_id
         job_root_dir = kubejob.get_job_root_dir_from_id(job_id)
         job_output_dir = os.path.join(job_root_dir, 'out')
 

--- a/src/templates/job.tpl.yaml
+++ b/src/templates/job.tpl.yaml
@@ -8,7 +8,7 @@ spec:
   parallelism: {{ replicas }}
   backoffLimit: {{ backoffLimit }}
   activeDeadlineSeconds: {{ activeDeadlineSeconds }}
-  ttlSecondsAfterFinished: 86400
+  ttlSecondsAfterFinished: {{ ttlSecondsAfterFinished }}
   template:
     metadata:
       labels:

--- a/src/userinfo.py
+++ b/src/userinfo.py
@@ -1,0 +1,56 @@
+import logging
+import re
+import requests
+
+from global_vars import config
+
+logger = logging.getLogger('pkg.auth.oauth2')
+logger.setLevel('DEBUG')
+
+
+SSL_VERIFY = True
+OAUTH_USERINFO_URL = config['oauth']['userInfoUrl']
+OAUTH_COOKIE_NAME = config['oauth']['cookieName']
+
+
+def userinfo(access_token) -> dict:
+    try:
+        resp = requests.get(url=OAUTH_USERINFO_URL,
+                            verify=SSL_VERIFY,
+                            cookies={"_oauth2_proxy": access_token})
+        resp.raise_for_status()
+        user = resp.json()
+
+        roles = []
+        for grp in user['groups']:
+            roles.append(grp)
+
+        # sub = user['preferredUsername'].replace('@', '').replace('.', '')
+        email = user['email']
+        username = re.sub(r'[^a-zA-Z0-9]', '', email)
+
+        # TODO: Hoping that oauth2-proxy enhances support for providing arbitrary token claims from OIDC
+        # See https://github.com/oauth2-proxy/oauth2-proxy/issues/834
+        return {
+            'email': user['email'],
+            'groups': roles,
+            # 'family_name': user['family_name'],
+            # 'given_name': user['given_name'],
+            'sub': username
+        }
+    except Exception as e:
+        logger.debug(f'OAuth2 token verification failed for token={str(access_token)}')
+        logger.warning(f'OAuth2 token verification failed: {str(e)}')
+        pass
+
+
+def get_token_from_request_cookies(request):
+    token = request.cookies[OAUTH_COOKIE_NAME].value if OAUTH_COOKIE_NAME in request.cookies else None
+    logger.debug('Found get_token: ' + str(token))
+    return token
+
+# TODO: required scopes currently ignored
+def validate_auth_cookie(request, required_scopes=[]):
+    token = get_token_from_request_cookies(request)
+    logger.debug('Found validate_token: ' + str(token))
+    return userinfo(token)

--- a/test/job_cannon.py
+++ b/test/job_cannon.py
@@ -20,8 +20,8 @@ from requests.exceptions import Timeout
 
 CONFIG = {
     # 'auth_token': os.environ['SPT_API_TOKEN'],
-    'apiBaseUrl': 'http://localhost:8888/api/v1',
-    #'apiBaseUrl': ' https://jobmgr.mmli1.ncsa.illinois.edu/api/v1',
+    #'apiBaseUrl': 'http://localhost:8888/api/v1',
+    'apiBaseUrl': ' https://jobmgr.mmli1.ncsa.illinois.edu/api/v1',
 }
 
 
@@ -157,6 +157,7 @@ def main():
             job_config = yaml.load(conf_file, Loader=yaml.FullLoader)
         # print(yaml.dump(job_config, indent=2))
 
+        # FIXME: remove quotes from token arg
         # Include our OAuth2 Proxy token cookie
         token = args.token.replace('"', '').replace("'", '')
 
@@ -164,7 +165,6 @@ def main():
         ##
         print(f'Submitting new MMLI job ({fileName}) with token={token}')
         job_info = submit_job(
-            # FIXME: remove quotes from token arg
             token=token,
             payload=job_config['input_fasta'],
             environment=[{'name': 'LOG_LEVEL', 'value': 'DEBUG'}]


### PR DESCRIPTION
## Problem
We need the JobManager API to include a small bit of Python to handle authentication/authorization

## Approach
* Deployed OAuth2 Proxy + Keycloak to the cluster: https://mmli1.nsca.illinois.edu/oauth2/start?rd=/oauth2/userinfo
* Cookie set by OAuth2 Proxy will be sent to JobManager API (if we set the cookie on the correct domains)
* Python checks for this cookie, and sends it back to OAuth2 Proxy to validate - this is similar to what we currently do for HCAPTCHA
    * If user is returned from our request, then we have our username, email, groups, etc
    * If no user is returned, then we return 401: Unauthorized
* Allow admin to override configs at runtime (this is still a little too fragile for my liking)

## How to Test
1. (already running in `staging`) Start this image up on the cluster using ArgoCD: `moleculemaker/mmli-job-manager:pr-22`
2. Navigate to https://jobmgr.mmli1.ncsa.illinois.edu/api/v1/uws/job
    * You should receive an error saying `401: Unauthorized` 
3. Navigate to https://mmli1.ncsa.illinois.edu/oauth2/start?rd=https://jobmgr.staging.mmli1.ncsa.illinois.edu/api/v1/uws/job
    * You should be redirected to Keycloak to login
4. Login or create an account in Keycloak
    * You should be redirected back to the JobManager API after you log in
    * You should see the list of Jobs submitted here
5. Logout by navigating to https://mmli1.ncsa.illinois.edu/oauth2/sign_out?rd=https://jobmgr.staging.mmli1.ncsa.illinois.edu/api/v1/uws/job
    * You should be redirected back to the JobManager API after you log out
    * You should once again see an error saying `401: Unauthorized` 