### PR TITLE
Add IP ratelimit middleware to JobMgr submit endpoint

### DIFF
--- a/chart/pvc-explorer.pod.yaml
+++ b/chart/pvc-explorer.pod.yaml
@@ -15,7 +15,7 @@ spec:
   volumes:
     - name: data
       persistentVolumeClaim:
-        # prodi / staging / localdev
+        # prod / staging / localdev
         claimName: mmli-clean-job-weights
 
         # local dev

--- a/chart/pvc-explorer.pod.yaml
+++ b/chart/pvc-explorer.pod.yaml
@@ -15,11 +15,9 @@ spec:
   volumes:
     - name: data
       persistentVolumeClaim:
+        # prodi / staging / localdev
+        claimName: mmli-clean-job-weights
+
         # local dev
         # claimName: job-manager-pvc
         
-        # prod
-        # claimName: mmli-clean-job-weights
-
-        # staging
-        claimName: mmli-clean-job-weights

--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -2,7 +2,7 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: jobs-api
+  name: {{ .Release.Name }}
 {{- with .Values.ingress.annotations }}
   annotations:
   {{- toYaml . | nindent 4 }}
@@ -27,4 +27,35 @@ spec:
             port:
               number: 8888
         path: /
+        pathType: ImplementationSpecific
+---
+# Enables us to add additional annotations to the /job/submit endpoint  (e.g. ratelimiting)
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .Release.Name }}-submit-endpoint
+{{- with .Values.jobSubmitIngress.annotations }}
+  annotations:
+  {{- toYaml . | nindent 4 }}
+{{- end }}
+spec:
+{{- if .Values.jobSubmitIngress.tls }}
+  tls:
+  - hosts:
+    - {{ .Values.jobSubmitIngress.hostname }}
+    secretName: {{ .Values.jobSubmitIngress.hostname }}-tls
+{{- end }}
+{{- if .Values.jobSubmitIngress.ingressClassName }}
+  ingressClassName: {{ .Values.jobSubmitIngress.ingressClassName }}
+{{- end }}
+  rules:
+  - host: {{ .Values.jobSubmitIngress.hostname | required "required: jobSubmitIngress.hostname (e.g. jobs.localhost)" }}
+    http:
+      paths:
+      - backend:
+          service:
+            name: {{ .Release.Name }}
+            port:
+              number: 8888
+        path: /api/v1/job/submit
         pathType: ImplementationSpecific

--- a/chart/values.local.yaml
+++ b/chart/values.local.yaml
@@ -1,12 +1,24 @@
 ingress:
-  ingressClassName: nginx
+  #ingressClassName: nginx
+  ingressClassName: traefik
   hostname: jobmgr.proxy.localhost
-  tls: true
+  tls: false
   annotations:
     nginx.ingress.kubernetes.io/enable-cors: "true"
     nginx.ingress.kubernetes.io/cors-allow-origin: "https://clean.proxy.localhost,https://molli.proxy.localhost,http://localhost:4200"
     nginx.ingress.kubernetes.io/cors-allow-credentials: "true"
+    traefik.ingress.kubernetes.io/router.middlewares: mmli-cors-header@kubernetescrd
 
+jobSubmitIngress:
+  #ingressClassName: nginx
+  ingressClassName: traefik
+  hostname: jobmgr.proxy.localhost
+  tls: false
+  annotations:
+    nginx.ingress.kubernetes.io/enable-cors: "true"
+    nginx.ingress.kubernetes.io/cors-allow-origin: "https://clean.proxy.localhost,https://molli.proxy.localhost,http://localhost:4200"
+    nginx.ingress.kubernetes.io/cors-allow-credentials: "true"
+    traefik.ingress.kubernetes.io/router.middlewares: mmli-cors-header@kubernetescrd,mmli-ip-ratelimit@kubernetescrd
 
 persistence:
   existingClaim: "mmli-clean-job-weights"  # use locally mounted data instead
@@ -15,7 +27,7 @@ persistence:
   storageClassName: hostpath
 
   # EXPERIMENTAL: Set this to enable mounting a directory into this volume from host
-  # hostpath: /Users/lambert8/workspace/mmli/mmli-job-manager/data
+  #hostpath: /Users/lambert8/workspace/mmli/mmli-job-manager/data
 
 
 controller:
@@ -41,7 +53,7 @@ config:
   hcaptcha:
     secret: "ChangeThisInProduction"
   oauth:
-    userInfoUrl: "http://oauth2-proxy.oauth2-proxy.svc.cluster.local/oauth2/userinfo"
+    userInfoUrl: "http://oauth2-proxy.mmli.svc.cluster.local/oauth2/userinfo"
   uws:
     imagePullSecret: "regcred"
     ## Server working directory to store generated job data

--- a/chart/values.prod.yaml
+++ b/chart/values.prod.yaml
@@ -42,8 +42,8 @@ extraDeploy:
     name: jobmgr-submit-ip-ratelimit
   spec:
     rateLimit:
-      average: 20
-      period: 500s
+      average: 4
+      period: 120s
 
 # Private git repo credentials
 - apiVersion: bitnami.com/v1alpha1

--- a/chart/values.prod.yaml
+++ b/chart/values.prod.yaml
@@ -5,6 +5,16 @@ ingress:
     cert-manager.io/cluster-issuer: letsencrypt-production
     kubernetes.io/tls-acme: "true"
     traefik.ingress.kubernetes.io/router.tls: "true"
+    traefik.ingress.kubernetes.io/router.middlewares: oauth2-proxy-cors-header@kubernetescrd
+
+jobSubmitIngress:
+  ingressClassName: traefik
+  hostname: jobmgr.mmli1.ncsa.illinois.edu
+  tls: true
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-production
+    kubernetes.io/tls-acme: "true"
+    traefik.ingress.kubernetes.io/router.tls: "true"
     traefik.ingress.kubernetes.io/router.middlewares: oauth2-proxy-cors-header@kubernetescrd,alphasynthesis-jobmgr-submit-ip-ratelimit@kubernetescrd
 
 persistence:

--- a/chart/values.prod.yaml
+++ b/chart/values.prod.yaml
@@ -5,7 +5,7 @@ ingress:
     cert-manager.io/cluster-issuer: letsencrypt-production
     kubernetes.io/tls-acme: "true"
     traefik.ingress.kubernetes.io/router.tls: "true"
-    traefik.ingress.kubernetes.io/router.middlewares: oauth2-proxy-cors-header@kubernetescrd
+    traefik.ingress.kubernetes.io/router.middlewares: oauth2-proxy-cors-header@kubernetescrd,oauth2-proxy-ip-ratelimit@kubernetescrd
 
 persistence:
   existingClaim: "mmli-clean-job-weights"

--- a/chart/values.prod.yaml
+++ b/chart/values.prod.yaml
@@ -5,7 +5,7 @@ ingress:
     cert-manager.io/cluster-issuer: letsencrypt-production
     kubernetes.io/tls-acme: "true"
     traefik.ingress.kubernetes.io/router.tls: "true"
-    traefik.ingress.kubernetes.io/router.middlewares: oauth2-proxy-cors-header@kubernetescrd,oauth2-proxy-ip-ratelimit@kubernetescrd
+    traefik.ingress.kubernetes.io/router.middlewares: oauth2-proxy-cors-header@kubernetescrd,alphasynthesis-jobmgr-submit-ip-ratelimit@kubernetescrd
 
 persistence:
   existingClaim: "mmli-clean-job-weights"
@@ -25,6 +25,16 @@ hcaptcha:
     existingSecret: "hcaptcha"
 
 extraDeploy:
+# IP ratelimiting for prod JobMgr
+- apiVersion: traefik.containo.us/v1alpha1
+  kind: Middleware
+  metadata:
+    name: jobmgr-submit-ip-ratelimit
+  spec:
+    rateLimit:
+      average: 20
+      period: 500s
+
 # Private git repo credentials
 - apiVersion: bitnami.com/v1alpha1
   kind: SealedSecret

--- a/chart/values.staging.yaml
+++ b/chart/values.staging.yaml
@@ -137,7 +137,7 @@ config:
     hostName: "jobmgr.staging.mmli1.ncsa.illinois.edu"
     namespace: "staging"
   oauth:
-    userInfoUrl: "http://oauth2-proxy.oauth2-proxy.svc.cluster.local/oauth2/userinfo"
+    userInfoUrl: "http://oauth2-proxy-staging.staging.svc.cluster.local/oauth2/userinfo"
   uws:
     imagePullSecret: "regcred"
     ## Server working directory to store generated job data

--- a/chart/values.staging.yaml
+++ b/chart/values.staging.yaml
@@ -7,6 +7,18 @@ ingress:
     traefik.ingress.kubernetes.io/router.tls: "true"
     traefik.ingress.kubernetes.io/router.middlewares: staging-cors-header@kubernetescrd
 
+jobSubmitIngress:
+  #ingressClassName: nginx
+  ingressClassName: traefik
+  hostname: jobmgr.proxy.localhost
+  tls: false
+  annotations:
+    nginx.ingress.kubernetes.io/enable-cors: "true"
+    nginx.ingress.kubernetes.io/cors-allow-origin: "https://clean.proxy.localhost,https://molli.proxy.localhost,http://localhost:4200"
+    nginx.ingress.kubernetes.io/cors-allow-credentials: "true"
+    traefik.ingress.kubernetes.io/router.middlewares: staging-cors-header@kubernetescrd,staging-jobmgr-submit-ip-ratelimit@kubernetescrd
+
+
 controller:
   image: moleculemaker/mmli-job-manager:staging
 
@@ -46,54 +58,15 @@ extraDeploy:
       type: kubernetes.io/dockerconfigjson
 
 
-
-# Deploy CORS middleware for staging namespace
+# IP ratelimiting for staging JobMgr
 - apiVersion: traefik.containo.us/v1alpha1
   kind: Middleware
   metadata:
-    name: cors-header
-    namespace: staging
+    name: jobmgr-submit-ip-ratelimit
   spec:
-    headers:
-      accessControlAllowCredentials: true
-      accessControlAllowHeaders:
-      - Origin
-      - X-Requested-With
-      - Content-Type
-      - content-type
-      - Accept
-      - Authorization
-      accessControlAllowMethods:
-      - GET
-      - OPTIONS
-      - PUT
-      - DELETE
-      - POST
-      accessControlAllowOriginList:
-      # Prod: chemscraper-frontend -> mmli-backend -> chemscraper-backend
-      - 'https://chemscraper.frontend.mmli1.ncsa.illinois.edu'
-      - 'https://mmli.fastapi.mmli1.ncsa.illinois.edu'	
-      - 'https://chemscraper.backend.mmli1.ncsa.illinois.edu'
-
-      # Prod: CLEAN / MOLLI -> JobMgr
-      - 'https://clean.frontend.mmli1.ncsa.illinois.edu'
-      - 'https://molli.frontend.mmli1.ncsa.illinois.edu'
-      - 'https://jobmgr.mmli1.ncsa.illinois.edu'
-
-      # Staging: chemscraper-frontend -> mmli-backend -> chemscraper-backend
-      - 'https://chemscraper.frontend.staging.mmli1.ncsa.illinois.edu'
-      - 'https://mmli.fastapi.staging.mmli1.ncsa.illinois.edu'
-      - 'https://chemscraper.backend.staging.mmli1.ncsa.illinois.edu'
-
-      # Staging: CLEAN / MOLLI -> JobMgr
-      - 'https://clean.frontend.staging.mmli1.ncsa.illinois.edu'
-      - 'https://molli.frontend.staging.mmli1.ncsa.illinois.edu'
-      - 'https://jobmgr.staging.mmli1.ncsa.illinois.edu'
-
-      # Local: for local testing pointed at staging
-      - 'http://localhost:4200'	
-      - 'http://chemscraper.proxy.localhost'
-      - 'http://test.mydomain.com'
+    rateLimit:
+      average: 20
+      period: 500s
 
 # Enable DecentCI backups
 - apiVersion: v1

--- a/chart/values.staging.yaml
+++ b/chart/values.staging.yaml
@@ -8,14 +8,13 @@ ingress:
     traefik.ingress.kubernetes.io/router.middlewares: staging-cors-header@kubernetescrd
 
 jobSubmitIngress:
-  #ingressClassName: nginx
   ingressClassName: traefik
-  hostname: jobmgr.proxy.localhost
-  tls: false
+  hostname: jobmgr.staging.mmli1.ncsa.illinois.edu
+  tls: true
   annotations:
-    nginx.ingress.kubernetes.io/enable-cors: "true"
-    nginx.ingress.kubernetes.io/cors-allow-origin: "https://clean.proxy.localhost,https://molli.proxy.localhost,http://localhost:4200"
-    nginx.ingress.kubernetes.io/cors-allow-credentials: "true"
+    cert-manager.io/cluster-issuer: letsencrypt-production
+    kubernetes.io/tls-acme: "true"
+    traefik.ingress.kubernetes.io/router.tls: "true"
     traefik.ingress.kubernetes.io/router.middlewares: staging-cors-header@kubernetescrd,staging-jobmgr-submit-ip-ratelimit@kubernetescrd
 
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,8 +1,10 @@
+# General ingress for all endpoints (except /api/v1/job/submit)
 ingress:
   hostname: jobmgr.proxy.localhost
   tls: false
   annotations: {}
-
+  
+# Custom ingress configuration for only /api/v1/job/submit endpoint
 jobSubmitIngress:
   hostname: jobmgr.proxy.localhost
   tls: false

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -3,6 +3,11 @@ ingress:
   tls: false
   annotations: {}
 
+jobSubmitIngress:
+  hostname: jobmgr.proxy.localhost
+  tls: false
+  annotations: {}
+
 controller:
   image: moleculemaker/mmli-job-manager:main
 


### PR DESCRIPTION
## Problem
We would like to ratelimit the JobMgr submit endpoint, while allowing unrestricted access to the other endpoints

## Approach
* split `/api/v1/job/submit` into its own ingress rule
* apply ip-ratelimit middleware to job submit endpoint (prod + staging)

![Screenshot_2023-12-01_at_11_59_39_AM](https://github.com/moleculemaker/mmli-job-manager/assets/1413653/dd7c0ed5-3385-402e-b262-915c35c9fe41)

## How to Test
1. Navigate to https://clean.frontend.staging.mmli1.ncsa.illinois.edu/configuration
2. Login using the link at the top-right (to avoid hcaptcha)
3. Paste the following example input and submit a new CLEAN job:
```
>WP_063460136
MAIPPYPDFRSAAFLRQHLRATMAFYDPVATDASGGQFHFFLDDGTVYNTHTRHLVSATRFVVTHAMLYRTTGEARYQVGMRHALEFLRTAFLDPATGGYAWLIDWQDGRATVQDTTRHCYGMAFVMLAYARAYEAGVPEARVWLAEAFDTAEQHFWQPAAGLYADEASPDWQLTSYRGQNANMHACEAMISAFRATGERRYIERAEQLAQGICQRQAALSDRTHAPAAEGWVWEHFHADWSVDWDYNRHDRSNIFRPWGYQVGHQTEWAKLLLQLDALLPADWHLPCAQRLFDTAVERGWDAEHGGLYYGMAPDGSICDDGKYHWVQAESMAAAAVLAVRTGDARYWQWYDRIWAYCWAHFVDHEHGAWFRILHRDNRNTTREKSNAGKVDYHNMGACYDVLLWALDAPGFSKESRSAALGRP
```
4. Click the browser's Back button and attempt to submit the same job again (within ~30s of the first submission)
    * You should see that Traefik rejects this request and returns `HTTP 429: Too Many Requests`
    * You should see that a response header is returned telling the user when they can retry the request again

