### PR TITLE
feat: upgrade kubernetes client from 11.0.0 -> 24.2.0, implement List+Watch in KubeWatcher

### DIFF
--- a/chart/values.prod.yaml
+++ b/chart/values.prod.yaml
@@ -1,5 +1,5 @@
 ingress:
-  hostname: jobmgr.mmli1.ncsa.illinois.edu
+  hostname: jobmgr.platform.moleculemaker.org
   tls: true
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-production
@@ -117,7 +117,8 @@ config:
   server:
     protocol: "https"
     ## API hostname. Must match the ingress.hostname value.
-    hostName: "jobmgr.mmli1.ncsa.illinois.edu"
+    ## Suffix must match CLEAN + MOLLI prod for user auth to work
+    hostName: "jobmgr.platform.moleculemaker.org"
     namespace: "alphasynthesis"
   oauth:
     userInfoUrl: "http://oauth2-proxy.oauth2-proxy.svc.cluster.local/oauth2/userinfo"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
-# kubernetes v12.0.0 breaks the kubejob.py code
-#	kubernetes == 11.0.0
 kubernetes == 24.2.0
 tornado == 6.1
 pyjson == 1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,11 @@
 # kubernetes v12.0.0 breaks the kubejob.py code
-kubernetes == 11.0.0
+#	kubernetes == 11.0.0
+kubernetes == 24.2.0
 tornado == 6.1
 pyjson == 1.3.0
 pyyaml == 5.4.1
 jinja2 == 3.0.1
-requests == 2.26
+requests
 bcrypt == 3.2.0
 pyjwt == 1.7.1
 mysql-connector-python-rf == 2.2.2

--- a/src/kubewatcher.py
+++ b/src/kubewatcher.py
@@ -3,6 +3,7 @@ import time
 import threading
 
 from kubernetes import watch, config as kubeconfig
+from kubernetes.client import V1JobList
 from kubernetes.client.rest import ApiException
 from requests import HTTPError
 
@@ -72,8 +73,8 @@ class KubeEventWatcher:
             self.logger.info('KubeWatcher is connecting...')
             try:
                 # List all pods in watched namespace to get resource_version
-                namespaced_jobs = kubejob.api_batch_v1.list_namespaced_job(namespace=kubejob.get_namespace())
-                resource_version = namespaced_jobs['metadata']['resource_version'] if 'metadata' in namespaced_jobs and 'resource_version' in namespaced_jobs['metadata'] else resource_version
+                namespaced_jobs: V1JobList = kubejob.api_batch_v1.list_namespaced_job(namespace=kubejob.get_namespace())
+                resource_version = namespaced_jobs.metadata['resource_version'] if 'resource_version' in namespaced_jobs.metadata else resource_version
 
                 # Then, watch for new events using the most recent resource_version
                 # Resource version is used to keep track of stream progress (in case of resume/retry)

--- a/src/kubewatcher.py
+++ b/src/kubewatcher.py
@@ -74,7 +74,7 @@ class KubeEventWatcher:
             try:
                 # List all pods in watched namespace to get resource_version
                 namespaced_jobs: V1JobList = kubejob.api_batch_v1.list_namespaced_job(namespace=kubejob.get_namespace())
-                resource_version = namespaced_jobs.metadata['resource_version'] if 'resource_version' in namespaced_jobs.metadata else resource_version
+                resource_version = namespaced_jobs.metadata.resource_version if namespaced_jobs.metadata.resource_version else resource_version
 
                 # Then, watch for new events using the most recent resource_version
                 # Resource version is used to keep track of stream progress (in case of resume/retry)

--- a/src/kubewatcher.py
+++ b/src/kubewatcher.py
@@ -73,8 +73,8 @@ class KubeEventWatcher:
                 # Resource version is used to keep track of stream progress (in case of resume)
                 k8s_event_stream = w.stream(func=kubejob.api_batch_v1.list_namespaced_job,
                                             namespace=kubejob.get_namespace(),
-                                            timeout_seconds=timeout_seconds,
-                                            resource_version=resource_version)
+                                            #resource_version=resource_version,
+                                            timeout_seconds=timeout_seconds)
 
                 self.logger.info('KubeWatcher connected!')
 

--- a/src/kubewatcher.py
+++ b/src/kubewatcher.py
@@ -62,6 +62,7 @@ class KubeEventWatcher:
         self.logger.info('KubeWatcher looking for required labels: ' + str(required_labels))
 
         timeout_seconds = 0
+        resource_version = ''
         k8s_event_stream = None
 
         w = watch.Watch()
@@ -72,7 +73,7 @@ class KubeEventWatcher:
             try:
                 # List all pods in watched namespace to get resource_version
                 namespaced_jobs = kubejob.api_batch_v1.list_namespaced_job(namespace=kubejob.get_namespace())
-                resource_version = namespaced_jobs['metadata']['resource_version'] if 'metadata' in namespaced_jobs and 'resource_version' in namespaced_jobs['metadata'] else ''
+                resource_version = namespaced_jobs['metadata']['resource_version'] if 'metadata' in namespaced_jobs and 'resource_version' in namespaced_jobs['metadata'] else resource_version
 
                 # Then, watch for new events using the most recent resource_version
                 # Resource version is used to keep track of stream progress (in case of resume/retry)
@@ -152,7 +153,7 @@ class KubeEventWatcher:
                 k8s_event_stream = None
                 if e.status == 410:
                     # Resource too old
-                    resource_version = None
+                    resource_version = ''
                     self.logger.warning("Resource too old (410) - reconnecting: " + str(e))
                 time.sleep(2)
                 continue


### PR DESCRIPTION
## Problem
Our Kubernetes Python client is horribly outdated

Intermittent HTTP 500 errors when connecting to Kube API. Once first encountered, this error loops endlessly

## Approach
* feat: upgrade Kubernetes client from 11.0.0 -> 24.2.0 - the major version should now match our current k8s version
* fix: workaround the issue described here: https://github.com/kubernetes-client/python/issues/1663
* fix: change production domain to `jobmgr.platform.moleculemaker.org`

## How to Test
This image has been deployed to [`job-manager-staging`](https://argocd.devops.ncsa.illinois.edu/applications/argocd/job-manager-staging?view=tree&resource=)

### CLEAN
1. Navigate to https://clean.frontend.staging.mmli1.ncsa.illinois.edu/configuration
2. Submit a new CLEAN job
3. Wait for job to complete

### MOLLI
1. Navigate to https://molli.frontend.staging.mmli1.ncsa.illinois.edu/configuration
2. Submit a new MOLLI job
3. Wait for job to complete

### Error Handling
With no way to reliably reproduce the error, all we can do is wait for a few days and watch the logs to see if the error surfaces again :pensive:

1. Switch to `mmli1` cluster: `kubectl config use-context mmli1`
2. Check logs for `job-manager-staging`: `kubectl logs -f deploy/job-manager-staging -n staging`
3. If you see the following error (it loops endlessly), then the issue has not been fixed:
```python
2023-12-17 14:35:22,708 [global_vars ] INFO     KubeWatcher is connecting...
2023-12-17 14:35:22,708 [global_vars ] INFO     KubeWatcher connected!
2023-12-17 14:35:22,716 [global_vars ] ERROR    HTTPError encountered - KubeWatcher reconnecting to Kube API: (500)
Reason: Internal Server Error
HTTP response headers: HTTPHeaderDict({'Audit-Id': '7f96ffff-4d2f-4354-ac60-dce5d41c931a', 'Cache-Control': 'no-cache, private', 'Content-Type': 'application/json', 'X-Kubernetes-Pf-Flowschema-Uid': '15dd202d-9244-45ab-a864-3f1580216460', 'X-Kubernetes-Pf-Prioritylevel-Uid': '504fafa2-5644-4478-8b81-9948f41552e2', 'Date': 'Sun, 17 Dec 2023 14:35:22 GMT', 'Content-Length': '186'})
HTTP response body: b'{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"resourceVersion: Invalid value: \\"None\\": strconv.ParseUint: parsing \\"None\\": invalid syntax","code":500}\n'
```